### PR TITLE
Add FEC FLR (Frame Loss Ratio) statistics support to port counters

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5649,11 +5649,11 @@ The "fec-stats" subcommand is used to disply the interface fec related statistic
 - Example:
   ```
   admin@ctd615:~$ show interfaces counters fec-stats
-        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
-  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------
-   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16
-   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14
-  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13
+        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FEC_FLR    FEC_FLR_PREDICTED
+  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  ---------  -------------------
+   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16          0                    0
+   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14          0                    0
+  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13          0                    0
   ```
 
 The "trim" subcommand is used to display the interface packet trimming related statistic.

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -45,12 +45,12 @@ Ethernet9      N/A        0      0.00 B/s       0.00/s        N/A         0     
 """  # noqa: E501
 
 intf_fec_counters = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------
-Ethernet0        D     130,402             3                 4            N/A             N/A                N/A
-Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A
-Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A
-Ethernet9      N/A           0             0                 0            N/A             N/A                N/A
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FEC_FLR    FEC_FLR_PREDICTED
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  ---------  -------------------
+Ethernet0        D     130,402             3                 4            N/A             N/A                N/A        N/A                  N/A
+Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A        N/A                  N/A
+Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A        N/A                  N/A
+Ethernet9      N/A           0             0                 0            N/A             N/A                N/A        N/A                  N/A
 """
 
 intf_fec_counters_nonzero = """\

--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -140,6 +140,17 @@ def format_fec_ber(rate):
     else:
         return "{:.2e}".format(float(rate))
 
+def format_fec_flr(rate):
+    """
+    Show the flr rate.
+    """
+    if rate == STATUS_NA:
+        return STATUS_NA
+    elif rate == 0:
+        return "0"
+    else:
+        return "{:.2e}".format(float(rate))
+
 
 def format_util(brate, port_rate):
     """

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -12,7 +12,7 @@ from utilities_common import constants
 import utilities_common.multi_asic as multi_asic_util
 from utilities_common.netstat import ns_diff, table_as_json, format_brate, format_prate, \
                                      format_util, format_number_with_comma, format_util_directly, \
-                                     format_fec_ber
+                                     format_fec_ber, format_fec_flr
 
 """
 The order and count of statistics mentioned below needs to be in sync with the values in portstat script
@@ -36,14 +36,14 @@ header_std = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP'
               'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_errors_only = ['IFACE', 'STATE', 'RX_ERR', 'RX_DRP', 'RX_OVR', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER',
-                   'FEC_POST_BER', 'FEC_PRE_BER_MAX']
+                   'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FEC_FLR', 'FEC_FLR_PREDICTED']
 header_rates_only = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_OK', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
 header_trim_only = ['IFACE', 'STATE', 'TRIM_PKTS', 'TRIM_TX_PKTS', 'TRIM_DRP_PKTS']
 
 rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER',
-                  'FEC_POST_BER', 'FEC_PRE_BER_MAX']
+                  'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FEC_FLR', 'FEC_FLR_PREDICTED']
 ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber", "fec_post_ber",
-                   "fec_pre_ber_max")
+                   "fec_pre_ber_max", "fec_flr", "fec_flr_predicted")
 RateStats = namedtuple("RateStats", ratestat_fields)
 
 """
@@ -248,11 +248,14 @@ class Portstat(object):
             fec_pre_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber")
             fec_post_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_post_ber")
             fec_pre_ber_max = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber_max")
+            fec_flr = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr")
+            fec_flr_predicted = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr_predicted")
             port_alias = key.split("|")[-1]
             cnstat_dict[port_alias] = NStats._make([rx_ok, rx_err, rx_drop, rx_ovr, tx_ok, tx_err, tx_drop, tx_ovr] +
                                                    [STATUS_NA] * (len(NStats._fields) - 8))._asdict()
             ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps,
-                                                        tx_pps, tx_util, fec_pre_ber, fec_post_ber, fec_pre_ber_max])
+                                                        tx_pps, tx_util, fec_pre_ber, fec_post_ber, fec_pre_ber_max,
+                                                        fec_flr, fec_flr_predicted])
         self.cnstat_dict.update(cnstat_dict)
         self.ratestat_dict.update(ratestat_dict)
 
@@ -333,7 +336,7 @@ class Portstat(object):
             """
                 Get the rates from specific table.
             """
-            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0"]
+            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data = self.db.get(self.db.COUNTERS_DB, full_table_id, name)
@@ -637,7 +640,9 @@ class Portstat(object):
                                   ns_diff(cntr['fec_symbol_err'], old_cntr['fec_symbol_err']),
                                   format_fec_ber(rates.fec_pre_ber),
                                   format_fec_ber(rates.fec_post_ber),
-                                  format_fec_ber(rates.fec_pre_ber_max)))
+                                  format_fec_ber(rates.fec_pre_ber_max),
+                                  format_fec_flr(rates.fec_flr),
+                                  format_fec_flr(rates.fec_flr_predicted)))
             elif rates_only:
                 header = header_rates_only
 


### PR DESCRIPTION
Add support to view FEC FLR (Frame Loss Ratio) statistics in 
port counter statistics.

This includes 
* FEC_FLR - observed FLR
* FEC_FLR_PREDICTED - predicted FLR computed by linear regression.

can be verified by viewing fec-stats either by `portstat -f` or ` show interfaces counters fec-stats `
 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added FEC FLR (Frame Loss Ratio) statistics support to port counters display, including both actual and predicted FLR values.

#### How I did it
Added format_fec_flr() function to format FLR values consistently
Extended header_fec_only to include FEC_FLR and FEC_FLR_PREDICTED columns
Updated RateStats namedtuple to include fec_flr and fec_flr_predicted fields
Modified port statistics collection to retrieve FLR values from CHASSIS_STATE_DB
Updated display formatting to show FLR columns in fec-stats output

#### How to verify it
Run show interfaces counters fec-stats command and verify the output includes the new FEC_FLR and FEC_FLR_PREDICTED columns with properly formatted values.

#### Previous command output (if the output of a command-line utility has changed)
  ```
  admin@ctd615:~$ show interfaces counters fec-stats
        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------
   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16
   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14
  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13
  ```

#### New command output (if the output of a command-line utility has changed)
  ```
  admin@ctd615:~$ show interfaces counters fec-stats
        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FEC_FLR    FEC_FLR_PREDICTED
  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  ---------  -------------------
   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16          0                    0
   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14          0                    0
  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13          0                    0
  ```

